### PR TITLE
Replace the custom SEO tags with Jekyll-seo-tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'github-pages'
 
 gem 'jekyll-sitemap'
 gem 'jekyll-feed'
+gem 'jekyll-seo-tag'
 
 gem 'rdiscount'
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,25 @@
 name: char1es
+title: char1es
 htmlname: <span class="title-base">char</span><span class="title-accent">1</span><span class="title-base">es</span>
-description: ''
+description: "Charles McEachern's blog"
 url: 'http://charles.uno'
 baseurl: ''
 github: 'https://github.com/chizarlicious'
+author:
+    twitter: charles_uno
+twitter:
+  username: charles_uno
+facebook:
+    publisher: https://www.facebook.com/charles.a.mceachern
+logo: null
+social:
+  name: Charles McEachern
+  links:
+    - https://twitter.com/charles_uno
+    - https://www.facebook.com/charles.a.mceachern
+    - https://www.linkedin.com/in/charlesmceachern
+    - https://plus.google.com/+CharlesMcEachern
+    - https://github.com/chizarlicious
 permalink: /:title/
 markdown: kramdown
 cdn: ''

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ cdn: ''
 gems:
   - jekyll-sitemap
   - jekyll-feed
+  - jekyll-seo-tag
 sass:
   sass_dir: /assets/_sass
   style: :compressed

--- a/_drafts/2016-11-12-election.md
+++ b/_drafts/2016-11-12-election.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Election"
 date: 2016-11-12
-thumb: "/thumbnails/flag.png"
+image: "/thumbnails/flag.png"
 description: It's nobody's fault, but our democracy is fucked.
 ---
 

--- a/_drafts/2016-11-19-democracy-vs-data.md
+++ b/_drafts/2016-11-19-democracy-vs-data.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Data vs Democracy"
 date: 2016-11-19
-thumb: "/thumbnails/map.png"
+image: "/thumbnails/map.png"
 description: ""
 ---
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,52 +15,6 @@ layout: compress
         <link rel="canonical" href="{{ page.redirect }}" />
     {% endif %}
 
-    <title>{{ site.name }}{% if page.title %} | {{ page.title }}{% endif %}</title>
-
-    <!--Twitter card and OpenGraph-->
-    {% if page.title == "Home" %}
-        <meta name="twitter:card" content="summary">
-    {% elsif page.id %}
-        <meta name="twitter:card" content="summary_large_image">
-    {% endif %}
-    <meta name="twitter:site" content="@charles_uno">
-    <meta name="twitter:creator" content="@charles_uno">
-    <meta name="og:site_name" content="charles.uno">
-    <!-- Title -->
-    {% if page.title == "Home" %}
-        <meta name="twitter:title" content="{{ site.name }}">
-        <meta property="og:title"  content="{{ site.name }}">
-    {% elsif page.title %}
-        <meta name="twitter:title" content="{{ page.title }}">
-        <meta property="og:title"  content="{{ page.title }}">
-    {% else %}
-        <meta name="twitter:title" content="{{ site.name }}">
-        <meta property="og:title"  content="{{ site.name }}">
-    {% endif %}
-    <!-- url -->
-    {% if page.url %}
-        <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
-        <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-    {% endif %}
-    <!-- Description -->
-    {% if page.description %}
-        <meta name="twitter:description" content="{{ page.description }}">
-        <meta property="og:description"  content="{{ page.description }}">
-    {% else %}
-        <meta name="twitter:description" content="{{ site.description }}">
-        <meta property="og:description"  content="{{ site.description }}">
-    {% endif %}
-    <!-- Image -->
-    {% if page.thumb %}
-        <meta name="twitter:image" content="{{ site.url }}/{{ page.thumb }}">
-        <meta property="og:image"  content="{{ site.url }}/{{ page.thumb }}">
-    {% endif %}
-    <!-- OpenGraph Type -->
-    {% if page.id %} <!-- Post -->
-        <meta property="og:type" content="article">
-        <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
-    {% endif %}
-
     <link href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl | prepend: site.url }}" rel="canonical">
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" rel="stylesheet">
     <!-- Support for icons better than the defaults -->
@@ -72,6 +26,9 @@ layout: compress
         <script src="//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
         <script src="//oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Jekyll-seo-tag -->
+    {% seo %}
 </head><body>
 
     <!-- Autocard handling -->

--- a/_posts/2014-03-14-shakshuka.md
+++ b/_posts/2014-03-14-shakshuka.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Shakshuka"
 date: 2014-03-14
-thumb: "/thumbnails/shakshuka.png"
+image: "/thumbnails/shakshuka.png"
 description: Placeholder description.
 ---
 

--- a/_posts/2016-04-25-bbft.md
+++ b/_posts/2016-04-25-bbft.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Banana Bread French Toast"
 date: 2016-04-25
-thumb: "/thumbnails/bbft.png"
-description: Placeholder description. 
+image: "/thumbnails/bbft.png"
+description: Placeholder description.
 author: charles
 ---
 

--- a/_posts/2016-05-27-tasp.md
+++ b/_posts/2016-05-27-tasp.md
@@ -2,7 +2,7 @@
 layout: post
 title: "The (Abridged) Skywalker Paradigm"
 date: 2016-05-27
-thumb: "/thumbnails/tasp.png"
+image: "/thumbnails/tasp.png"
 description: "I'm not trying to tell you about the plot holes in Star Wars - I'm telling you there are NO plot holes in Star Wars."
 author: charles
 ---

--- a/_posts/2016-11-24-resume.md
+++ b/_posts/2016-11-24-resume.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Resume"
 date: 2016-11-24
-thumb: "/thumbnails/aurora.png"
+image: "/thumbnails/aurora.png"
 description: Placeholder description.
 author: charles
 ---

--- a/_posts/2016-11-25-about.md
+++ b/_posts/2016-11-25-about.md
@@ -2,7 +2,7 @@
 layout: post
 title: "About"
 date: 2016-11-25
-thumb: "/thumbnails/about.png"
+image: "/thumbnails/about.png"
 description: Placeholder description.
 author: charles
 ---

--- a/_posts/2016-11-27-aunt-marys-cranberries.md
+++ b/_posts/2016-11-27-aunt-marys-cranberries.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Aunt Mary's Cranberries"
 date: 2016-11-27
-thumb: "/thumbnails/aunt-marys-cranberries.png"
+image: "/thumbnails/aunt-marys-cranberries.png"
 description: A simple side filled with fresh fruit flavor.
 author: charles
 ---

--- a/_posts/2016-11-27-roasted-cauliflower.md
+++ b/_posts/2016-11-27-roasted-cauliflower.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Roasted Cauliflower"
 date: 2016-11-27
-thumb: "/thumbnails/roasted-cauliflower.png"
+image: "/thumbnails/roasted-cauliflower.png"
 description: Steam your pores, not your vegetables.
 author: charles
 ---

--- a/assets/_js/index.js
+++ b/assets/_js/index.js
@@ -5,7 +5,7 @@ var themes = [
         {
             "title": "{{ theme.title }}",
             "date": "{{ theme.date | date: "%Y—%m—%-d" }}",
-            "thumbnail": "{{ theme.thumb }}",
+            "thumbnail": "{{ theme.image }}",
             "author": "{{ theme.author }}",
             "url": "{{ site.baseurl }}{{ theme.url }}",
             "stars": "{{ theme.stars }}",

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: default
                         <h2 class="index-name">{{ post.title }}</h2>
                     </div>
                 </a>
-                <img src="{{ post.thumb }}" class="index-thumb" />
+                <img src="{{ post.image }}" class="index-thumb" />
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
This package (supported by github pages) will automatically generate OpenGraph, Twitter Card, and various metadata tags for each page.