### PR TITLE
Remove unused `post.author` variable

### DIFF
--- a/_posts/2016-11-25-about.md
+++ b/_posts/2016-11-25-about.md
@@ -3,7 +3,6 @@ layout: post
 title: "\0About"
 date: 2016-11-25
 image: "/thumbnails/about.png"
-author: charles
 ---
 
 Welcome!

--- a/_posts/2016-11-26-roasted-cauliflower.md
+++ b/_posts/2016-11-26-roasted-cauliflower.md
@@ -3,7 +3,6 @@ layout: post
 title: "Roasted Cauliflower"
 image: "/thumbnails/roasted-cauliflower.png"
 description: Steam your pores, not your vegetables.
-author: charles
 ---
 
 Partition **one large head of cauliflower** (or two small heads) into 3cm (1 inch) florets. In a large bowl, toss with about **50ml olive oil** (3T), until evenly coated. Sprinkle lightly with **salt** and heavily with **black pepper**.

--- a/_posts/2016-11-27-aunt-marys-cranberries.md
+++ b/_posts/2016-11-27-aunt-marys-cranberries.md
@@ -3,7 +3,6 @@ layout: post
 title: "Aunt Mary's Cranberries"
 image: "/thumbnails/aunt-marys-cranberries.png"
 description: A simple side filled with fresh fruit flavor.
-author: charles
 ---
 
 This recipe assumes a large food processor. If yours is more modestly sized, it may be better to do half at a time.

--- a/_posts/2016-12-09-the-abridged-skywalker-paradigm.md
+++ b/_posts/2016-12-09-the-abridged-skywalker-paradigm.md
@@ -3,7 +3,6 @@ layout: post
 title: "The (Abridged) Skywalker Paradigm"
 image: "/thumbnails/the-abridged-skywalker-paradigm.png"
 description: "I'm not trying to tell you about the plot holes in Star Wars -- I'm telling you there are NO plot holes in Star Wars."
-author: charles
 ---
 
 Some time ago, I stumbled upon The [Skywalker Paradigm](http://ammonra.org/skywalkerparadigm/), a sort of Star Wars conspiracy theory. Here's how it introduces itself:

--- a/_posts/2016-12-10-shakshuka.md
+++ b/_posts/2016-12-10-shakshuka.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: "Shakshuka"
-author: charles
 image: "/thumbnails/shakshuka.png"
 description: "This spicy egg and tomato dish is perfect for brunch, dinner, or brunch-for-dinner."
 ---

--- a/_posts/2016-12-18-data-vs-democracy.md
+++ b/_posts/2016-12-18-data-vs-democracy.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: "Data vs Democracy"
-author: charles
 image: "/thumbnails/dukakis.png"
 description: "Our data consumption has grown exponentially in the past half-century, and it's brought us way too close to the sausage-making process."
 ---

--- a/_posts/2016-12-20-banana-bread-french-toast.md
+++ b/_posts/2016-12-20-banana-bread-french-toast.md
@@ -3,25 +3,24 @@ layout: post
 title: "Banana Bread French Toast"
 image: "/thumbnails/banana-bread-french-toast.png"
 description: "A decadent treat for Saturday morning or Sunday night."
-author: charles
 ---
 
-Combine **150 ml brown sugar** (2/3 c), **75 ml softened butter** (1/3 c, or 2/3 stick), **1 egg**, and **5 ml vanilla** (1 t). Add **4 overripe bananas**[^1]. In a separate bowl, mix **250 ml whole wheat flour** (1 c) with **5 ml salt** (1 t) and **5 ml baking soda** (1 t). Gradually mix the dry ingredients into the wet ingredients. The mixture should have about the consistency of mixed-up yogurt; if it's too soupy, you may need to add a bit more flour. 
+Combine **150 ml brown sugar** (2/3 c), **75 ml softened butter** (1/3 c, or 2/3 stick), **1 egg**, and **5 ml vanilla** (1 t). Add **4 overripe bananas**[^1]. In a separate bowl, mix **250 ml whole wheat flour** (1 c) with **5 ml salt** (1 t) and **5 ml baking soda** (1 t). Gradually mix the dry ingredients into the wet ingredients. The mixture should have about the consistency of mixed-up yogurt; if it's too soupy, you may need to add a bit more flour.
 
-[^1]: Optionally, bananas can be swapped out for 400 ml (14 oz) cooked/canned sweet potato or squash. 
+[^1]: Optionally, bananas can be swapped out for 400 ml (14 oz) cooked/canned sweet potato or squash.
 
-Add **125 ml mini dark chocolate chips**[^2] (1/2 c). Then spoon the batter into a buttered loaf pan[^3] and bake at 190C (375F) until a toothpick inserted into the center comes out clean, about 45 minutes. Allow the loaf to cool, then carefully remove it from the pan. Banana bread can be stored at room temperature for a few days; keep a towel over it to prevent it from going stale. 
+Add **125 ml mini dark chocolate chips**[^2] (1/2 c). Then spoon the batter into a buttered loaf pan[^3] and bake at 190C (375F) until a toothpick inserted into the center comes out clean, about 45 minutes. Allow the loaf to cool, then carefully remove it from the pan. Banana bread can be stored at room temperature for a few days; keep a towel over it to prevent it from going stale.
 
-[^2]: Chopped nuts and dried cranberries are suitable substitutes for chocolate chips. 
+[^2]: Chopped nuts and dried cranberries are suitable substitutes for chocolate chips.
 
-[^3]: Bake time is closer to 25 minutes for muffins, or 15 minutes for mini muffins. Muffins aren't much use for making french toast, but they're great for snacking and sharing. 
+[^3]: Bake time is closer to 25 minutes for muffins, or 15 minutes for mini muffins. Muffins aren't much use for making french toast, but they're great for snacking and sharing.
 
 ![Banana bread loaf](/assets/images/bbft/loaf.jpg)
 *The ends of the loaf make for unsightly french toast, so you should probably just eat them.*
 
-Slice the loaf (or whatever is left of it) as thin as you can without having it fall apart. Mix **3 eggs**, **75 ml plain yogurt** (1/3 c), and **cinnamon** to taste. Dip each slice in the egg mixture, coating both sides, then fry in a buttered skillet until golden brown. 
+Slice the loaf (or whatever is left of it) as thin as you can without having it fall apart. Mix **3 eggs**, **75 ml plain yogurt** (1/3 c), and **cinnamon** to taste. Dip each slice in the egg mixture, coating both sides, then fry in a buttered skillet until golden brown.
 
-Banana bread french toast is decadent on its own; syrup is not necessary (though a dribble never hurt anybody). It's best with fresh fruit and/or peanut butter. 
+Banana bread french toast is decadent on its own; syrup is not necessary (though a dribble never hurt anybody). It's best with fresh fruit and/or peanut butter.
 
 ![Banana bread french toast](/assets/images/bbft/final.jpg)
 *One slice is typical. Two slices is ambitious. Three slices is madness.*

--- a/_posts/2017-01-08-rock-paper-pokemon.md
+++ b/_posts/2017-01-08-rock-paper-pokemon.md
@@ -3,7 +3,6 @@ layout: post
 title: "Rock Paper Pokémon"
 image: "/thumbnails/rock-paper-pokemon.png"
 description: "Rock beats Ice. Bug beats Psychic. Fairy beats Dragon. What might the Pokémon type system look like if it hadn't jumped the shark?"
-author: charles
 ---
 
 In the Pokémon universe, each trainer carries a team of pocket monsters with them at all times. When two trainers make eye contact, they are honor-bound to battle. The battle cannot end until one trainer wins, by knocking the other trainer's entire team unconscious. The winner earns both money and social status.

--- a/assets/_js/index.js
+++ b/assets/_js/index.js
@@ -7,7 +7,6 @@ var posts = [
             "hash": "{{ post.title | remove: ' ' | strip_newlines | downcase | md5 }}",
             "date": "{{ post.date | date: "%Y—%m—%d" }}",
             "thumbnail": "{{ post.image }}",
-            "author": "{{ post.author }}",
             "url": "{{ site.baseurl }}{{ post.url }}",
         }{% unless forloop.last %},{% endunless %}
     {% endfor %}


### PR DESCRIPTION
This variable was only used by Jekyll-seo-tag, where it overrides the
site default author. The fixes the bug where the `twitter:creator` tag
was incorrectly set to "@charles".

I also remove the JS variable "author" from the posts object. It is unused, but for some reason changing it to be the site author changed the column layout. Probably because the site author is longer? Unclear... Hooray front end development!