### PR TITLE
Fix jekyll-feed author variable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ url: 'http://charles.uno'
 baseurl: ''
 github: 'https://github.com/chizarlicious'
 author:
+    name: Charles McEachern
     twitter: charles_uno
 twitter:
   username: charles_uno


### PR DESCRIPTION
Previously it was using `{"twitter" => "charles_uno"}`; now it will use
"Charles McEachern".